### PR TITLE
Added the tests named Test*2()

### DIFF
--- a/PageObjects/JeffPage.cs
+++ b/PageObjects/JeffPage.cs
@@ -1,0 +1,70 @@
+using NUnit.Framework;
+
+using OpenQA.Selenium;
+using OpenQA.Selenium.Interactions;
+using OpenQA.Selenium.Support.UI;
+
+using System;
+using System.Collections;
+using System.Collections.ObjectModel;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace WFMPractice
+{
+    public class JeffMainPage : WFMUtils.POM
+    {
+        public JeffMainPage(IWebDriver aDriver) 
+            : base(
+                "/main", 
+                aDriver
+            )
+        {
+            this.AddSelDescriptor(
+                "WeeklySales", 
+                By.XPath("//*[@class='menu__nav menu--main__nav']//*[text()='Weekly Sales']"),
+                new Dictionary<string,string>{
+                    {"isStatic", "y"}
+                }
+            );
+            this.AddSelDescriptor(
+                "Tips&Ideas", 
+                By.XPath("//*[@class='menu__nav menu--main__nav']//*[text()='Tips & Ideas']"),
+                new Dictionary<string,string>{
+                    {"isStatic", "y"}
+                }
+            );
+            this.AddSelDescriptor(
+                "StoreLocator", 
+                By.XPath("//*[@class='menu__nav menu--main__nav']//*[text()='Store Locator']"),
+                new Dictionary<string,string>{
+                    {"isStatic", "y"}
+                }
+            );
+            this.AddSelDescriptor(
+                "BrowseProducts", 
+                By.XPath("//*[@class='menu__nav menu--main__nav']//*[text()='Browse Products']"),
+                new Dictionary<string,string>{
+                    {"isStatic", "y"}
+                }
+            );
+            this.AddSelDescriptor(
+                "Covid19Update", 
+                By.XPath("//*[@class='menu__nav menu--main__nav']//*[text()='COVID-19 Update']"),
+                new Dictionary<string,string>{
+                    {"isStatic", "y"}
+                }
+            );
+        }
+
+        public void ClickToBrowseProductsMenu(int MaxWaitTimeInSecs=10)
+        {
+            driver.FindElement(this.GetBySelector("BrowseProducts")).Click();
+            WFMUtils.WaitForCurrPageToFinishLoading(driver, MaxWaitTimeInSecs);
+            Assert.That(driver.Url, Does.StartWith("https://products.wholefoodsmarket.com/"));
+        }
+    }
+}

--- a/PageObjects/PrescriptiveBrowseProductsPage.cs
+++ b/PageObjects/PrescriptiveBrowseProductsPage.cs
@@ -1,0 +1,42 @@
+using NUnit.Framework;
+
+using OpenQA.Selenium;
+using OpenQA.Selenium.Interactions;
+using OpenQA.Selenium.Support.UI;
+
+using System;
+using System.Collections;
+using System.Collections.ObjectModel;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace WFMPractice
+{
+    public class PrescriptiveBrowseProductsPage : WFMUtils.POM
+    {
+        public PrescriptiveBrowseProductsPage(IWebDriver aDriver) 
+            : base(
+                "/BrowseProducts", 
+                aDriver
+            )
+        {
+            this.AddSelDescriptor(
+                "HomeLogoLink", 
+                By.CssSelector("a[aria-label='Whole Foods Market']"),
+                new Dictionary<string,string>{
+                    {"isStatic", "y"}
+                }
+            );
+        }
+
+        public void ClickToHomePage(int MaxWaitTimeInSecs=10)
+        {
+            ClickEltByName("HomeLogoLink");
+            WFMUtils.WaitForCurrPageToFinishLoading(driver, MaxWaitTimeInSecs);
+            Assert.That(driver.Url, Does.StartWith("https://www.wholefoodsmarket.com/"));
+        }
+    }
+}

--- a/PageObjects/PrescriptiveMainPage.cs
+++ b/PageObjects/PrescriptiveMainPage.cs
@@ -27,7 +27,7 @@ namespace WFMPractice
                 "HomeLogoLink", 
                 By.CssSelector(".logo__link"),
                 new Dictionary<string,string>{
-                    {"isStatic", "y"},
+                    {WFMUtils.SelDescriptor.StdAttrNames.IsStatic, "y"},
                     {"clickCausesPageLoad", "y"}
                 }
             );
@@ -35,7 +35,7 @@ namespace WFMPractice
                 "Menu_WeeklySales", 
                 By.XPath("//*[@class='menu__nav menu--main__nav']//*[text()='Weekly Sales']"),
                 new Dictionary<string,string>{
-                    {"isStatic", "y"},
+                    {WFMUtils.SelDescriptor.StdAttrNames.IsStatic, "y"},
                     {"clickCausesPageLoad", "y"}
                 }
             );
@@ -43,7 +43,7 @@ namespace WFMPractice
                 "Button_SeeWeeklySales", 
                 By.XPath("//a[text()='See weekly sales']"),
                 new Dictionary<string,string>{
-                    {"isStatic", "y"},
+                    {WFMUtils.SelDescriptor.StdAttrNames.IsStatic, "y"},
                     {"clickCausesPageLoad", "y"}
                 }
             );
@@ -51,7 +51,7 @@ namespace WFMPractice
                 "Menu_Tips&Ideas", 
                 By.XPath("//*[@class='menu__nav menu--main__nav']//*[text()='Tips & Ideas']"),
                 new Dictionary<string,string>{
-                    {"isStatic", "y"},
+                    {WFMUtils.SelDescriptor.StdAttrNames.IsStatic, "y"},
                     {"clickCausesPageLoad", "y"}
                 }
             );
@@ -59,7 +59,7 @@ namespace WFMPractice
                 "Menu_StoreLocator", 
                 By.XPath("//*[@class='menu__nav menu--main__nav']//*[text()='Store Locator']"),
                 new Dictionary<string,string>{
-                    {"isStatic", "y"},
+                    {WFMUtils.SelDescriptor.StdAttrNames.IsStatic, "y"},
                     {"clickCausesPageLoad", "y"}
                 }
             );
@@ -67,7 +67,7 @@ namespace WFMPractice
                 "Button_FindAStore", 
                 By.XPath("//a[text()='Find a store']"),
                 new Dictionary<string,string>{
-                    {"isStatic", "y"},
+                    {WFMUtils.SelDescriptor.StdAttrNames.IsStatic, "y"},
                     {"clickCausesPageLoad", "y"}
                 }
             );
@@ -75,7 +75,7 @@ namespace WFMPractice
                 "Button_FindYourStore", 
                 By.XPath("//a[text()='Find your store']"),
                 new Dictionary<string,string>{
-                    {"isStatic", "y"},
+                    {WFMUtils.SelDescriptor.StdAttrNames.IsStatic, "y"},
                     {"clickCausesPageLoad", "y"}
                 }
             );
@@ -83,7 +83,7 @@ namespace WFMPractice
                 "Menu_BrowseProducts", 
                 By.XPath("//*[@class='menu__nav menu--main__nav']//*[text()='Browse Products']"),
                 new Dictionary<string,string>{
-                    {"isStatic", "y"},
+                    {WFMUtils.SelDescriptor.StdAttrNames.IsStatic, "y"},
                     {"clickCausesPageLoad", "y"}
                 }
             );
@@ -91,7 +91,7 @@ namespace WFMPractice
                 "Button_BrowseProducts", 
                 By.XPath("//a[text()='Browse products']"),
                 new Dictionary<string,string>{
-                    {"isStatic", "y"},
+                    {WFMUtils.SelDescriptor.StdAttrNames.IsStatic, "y"},
                     {"clickCausesPageLoad", "y"}
                 }
             );
@@ -99,7 +99,7 @@ namespace WFMPractice
                 "Button_GetDelivery&Pickup", 
                 By.XPath("//a[text()='Get delivery & pickup']"),
                 new Dictionary<string,string>{
-                    {"isStatic", "y"},
+                    {WFMUtils.SelDescriptor.StdAttrNames.IsStatic, "y"},
                     {"clickCausesPageLoad", "y"}
                 }
             );
@@ -107,7 +107,7 @@ namespace WFMPractice
                 "Menu_Covid19Update", 
                 By.XPath("//*[@class='menu__nav menu--main__nav']//*[text()='COVID-19 Update']"),
                 new Dictionary<string,string>{
-                    {"isStatic", "y"},
+                    {WFMUtils.SelDescriptor.StdAttrNames.IsStatic, "y"},
                     {"clickCausesPageLoad", "y"}
                 }
             );

--- a/PageObjects/PrescriptiveMainPage.cs
+++ b/PageObjects/PrescriptiveMainPage.cs
@@ -19,10 +19,17 @@ namespace WFMPractice
     {
         public PrescriptiveMainPage(IWebDriver aDriver) 
             : base(
-                "/main", 
+                "/Main", 
                 aDriver
             )
         {
+            this.AddSelDescriptor(
+                "HomeLogoLink", 
+                By.CssSelector(".logo__link"),
+                new Dictionary<string,string>{
+                    {"isStatic", "y"}
+                }
+            );
             this.AddSelDescriptor(
                 "WeeklySales", 
                 By.XPath("//*[@class='menu__nav menu--main__nav']//*[text()='Weekly Sales']"),
@@ -60,35 +67,43 @@ namespace WFMPractice
             );
         }
 
-        public void ClickToWeeklySalesMenu(int MaxWaitTimeInSecs=10)
+        public void ClickToHomePage(int MaxWaitTimeInSecs=10)
+        {
+            ClickEltByName("HomeLogoLink");
+            WFMUtils.WaitForCurrPageToFinishLoading(driver, MaxWaitTimeInSecs);
+            Assert.That(driver.Url, Does.StartWith("https://www.wholefoodsmarket.com/"));
+        }
+
+
+        public void ClickToWeeklySalesPage(int MaxWaitTimeInSecs=10)
         {
             ClickEltByName("WeeklySales");
             WFMUtils.WaitForCurrPageToFinishLoading(driver, MaxWaitTimeInSecs);
             Assert.That(driver.Url, Does.StartWith("https://www.wholefoodsmarket.com/sales-flyer"));
         }
 
-        public void ClickToTipsAndIdeasMenu(int MaxWaitTimeInSecs=10)
+        public void ClickToTipsAndIdeasPage(int MaxWaitTimeInSecs=10)
         {
             ClickEltByName("Tips&Ideas");
             WFMUtils.WaitForCurrPageToFinishLoading(driver, MaxWaitTimeInSecs);
             Assert.That(driver.Url, Does.StartWith("https://inspiration.wholefoodsmarket.com/"));
         }
 
-        public void ClickToStoreLocatorMenu(int MaxWaitTimeInSecs=10)
+        public void ClickToStoreLocatorPage(int MaxWaitTimeInSecs=10)
         {
             ClickEltByName("StoreLocator");
             WFMUtils.WaitForCurrPageToFinishLoading(driver, MaxWaitTimeInSecs);
             Assert.That(driver.Url, Does.StartWith("https://www.wholefoodsmarket.com/stores"));
         }
 
-        public void ClickToBrowseProductsMenu(int MaxWaitTimeInSecs=10)
+        public void ClickToBrowseProductsPage(int MaxWaitTimeInSecs=10)
         {
             ClickEltByName("BrowseProducts");
             WFMUtils.WaitForCurrPageToFinishLoading(driver, MaxWaitTimeInSecs);
             Assert.That(driver.Url, Does.StartWith("https://products.wholefoodsmarket.com/"));
         }
 
-        public void ClickToCovid19UpdateMenu(int MaxWaitTimeInSecs=10)
+        public void ClickToCovid19UpdatePage(int MaxWaitTimeInSecs=10)
         {
             ClickEltByName("Covid19Update");
             WFMUtils.WaitForCurrPageToFinishLoading(driver, MaxWaitTimeInSecs);

--- a/PageObjects/PrescriptiveMainPage.cs
+++ b/PageObjects/PrescriptiveMainPage.cs
@@ -15,9 +15,9 @@ using System.Threading.Tasks;
 
 namespace WFMPractice
 {
-    public class JeffMainPage : WFMUtils.POM
+    public class PrescriptiveMainPage : WFMUtils.POM
     {
-        public JeffMainPage(IWebDriver aDriver) 
+        public PrescriptiveMainPage(IWebDriver aDriver) 
             : base(
                 "/main", 
                 aDriver

--- a/PageObjects/PrescriptiveMainPage.cs
+++ b/PageObjects/PrescriptiveMainPage.cs
@@ -72,6 +72,14 @@ namespace WFMPractice
                 }
             );
             this.AddSelDescriptor(
+                "Button_FindYourStore", 
+                By.XPath("//a[text()='Find your store']"),
+                new Dictionary<string,string>{
+                    {"isStatic", "y"},
+                    {"clickCausesPageLoad", "y"}
+                }
+            );
+            this.AddSelDescriptor(
                 "Menu_BrowseProducts", 
                 By.XPath("//*[@class='menu__nav menu--main__nav']//*[text()='Browse Products']"),
                 new Dictionary<string,string>{
@@ -144,6 +152,13 @@ namespace WFMPractice
         public void ClickButton_FindAStore(int MaxWaitTimeInSecs=10)
         {
             ClickEltByName("Button_FindAStore");
+            // WFMUtils.WaitForCurrPageToFinishLoading(driver, MaxWaitTimeInSecs);
+            Assert.That(driver.Url, Does.StartWith("https://www.wholefoodsmarket.com/stores"));
+        }
+
+        public void ClickButton_FindYourStore(int MaxWaitTimeInSecs=10)
+        {
+            ClickEltByName("Button_FindYourStore");
             // WFMUtils.WaitForCurrPageToFinishLoading(driver, MaxWaitTimeInSecs);
             Assert.That(driver.Url, Does.StartWith("https://www.wholefoodsmarket.com/stores"));
         }

--- a/PageObjects/PrescriptiveMainPage.cs
+++ b/PageObjects/PrescriptiveMainPage.cs
@@ -28,7 +28,7 @@ namespace WFMPractice
                 By.CssSelector(".logo__link"),
                 new Dictionary<string,string>{
                     {WFMUtils.SelDescriptor.StdAttrNames.IsStatic, "y"},
-                    {"clickCausesPageLoad", "y"}
+                    {WFMUtils.SelDescriptor.StdAttrNames.ClickCausesPageLoad, "y"}
                 }
             );
             this.AddSelDescriptor(
@@ -36,7 +36,7 @@ namespace WFMPractice
                 By.XPath("//*[@class='menu__nav menu--main__nav']//*[text()='Weekly Sales']"),
                 new Dictionary<string,string>{
                     {WFMUtils.SelDescriptor.StdAttrNames.IsStatic, "y"},
-                    {"clickCausesPageLoad", "y"}
+                    {WFMUtils.SelDescriptor.StdAttrNames.ClickCausesPageLoad, "y"}
                 }
             );
             this.AddSelDescriptor(
@@ -44,7 +44,7 @@ namespace WFMPractice
                 By.XPath("//a[text()='See weekly sales']"),
                 new Dictionary<string,string>{
                     {WFMUtils.SelDescriptor.StdAttrNames.IsStatic, "y"},
-                    {"clickCausesPageLoad", "y"}
+                    {WFMUtils.SelDescriptor.StdAttrNames.ClickCausesPageLoad, "y"}
                 }
             );
             this.AddSelDescriptor(
@@ -52,7 +52,7 @@ namespace WFMPractice
                 By.XPath("//*[@class='menu__nav menu--main__nav']//*[text()='Tips & Ideas']"),
                 new Dictionary<string,string>{
                     {WFMUtils.SelDescriptor.StdAttrNames.IsStatic, "y"},
-                    {"clickCausesPageLoad", "y"}
+                    {WFMUtils.SelDescriptor.StdAttrNames.ClickCausesPageLoad, "y"}
                 }
             );
             this.AddSelDescriptor(
@@ -60,7 +60,7 @@ namespace WFMPractice
                 By.XPath("//*[@class='menu__nav menu--main__nav']//*[text()='Store Locator']"),
                 new Dictionary<string,string>{
                     {WFMUtils.SelDescriptor.StdAttrNames.IsStatic, "y"},
-                    {"clickCausesPageLoad", "y"}
+                    {WFMUtils.SelDescriptor.StdAttrNames.ClickCausesPageLoad, "y"}
                 }
             );
             this.AddSelDescriptor(
@@ -68,7 +68,7 @@ namespace WFMPractice
                 By.XPath("//a[text()='Find a store']"),
                 new Dictionary<string,string>{
                     {WFMUtils.SelDescriptor.StdAttrNames.IsStatic, "y"},
-                    {"clickCausesPageLoad", "y"}
+                    {WFMUtils.SelDescriptor.StdAttrNames.ClickCausesPageLoad, "y"}
                 }
             );
             this.AddSelDescriptor(
@@ -76,7 +76,7 @@ namespace WFMPractice
                 By.XPath("//a[text()='Find your store']"),
                 new Dictionary<string,string>{
                     {WFMUtils.SelDescriptor.StdAttrNames.IsStatic, "y"},
-                    {"clickCausesPageLoad", "y"}
+                    {WFMUtils.SelDescriptor.StdAttrNames.ClickCausesPageLoad, "y"}
                 }
             );
             this.AddSelDescriptor(
@@ -84,7 +84,7 @@ namespace WFMPractice
                 By.XPath("//*[@class='menu__nav menu--main__nav']//*[text()='Browse Products']"),
                 new Dictionary<string,string>{
                     {WFMUtils.SelDescriptor.StdAttrNames.IsStatic, "y"},
-                    {"clickCausesPageLoad", "y"}
+                    {WFMUtils.SelDescriptor.StdAttrNames.ClickCausesPageLoad, "y"}
                 }
             );
             this.AddSelDescriptor(
@@ -92,7 +92,7 @@ namespace WFMPractice
                 By.XPath("//a[text()='Browse products']"),
                 new Dictionary<string,string>{
                     {WFMUtils.SelDescriptor.StdAttrNames.IsStatic, "y"},
-                    {"clickCausesPageLoad", "y"}
+                    {WFMUtils.SelDescriptor.StdAttrNames.ClickCausesPageLoad, "y"}
                 }
             );
             this.AddSelDescriptor(
@@ -100,7 +100,7 @@ namespace WFMPractice
                 By.XPath("//a[text()='Get delivery & pickup']"),
                 new Dictionary<string,string>{
                     {WFMUtils.SelDescriptor.StdAttrNames.IsStatic, "y"},
-                    {"clickCausesPageLoad", "y"}
+                    {WFMUtils.SelDescriptor.StdAttrNames.ClickCausesPageLoad, "y"}
                 }
             );
             this.AddSelDescriptor(
@@ -108,7 +108,7 @@ namespace WFMPractice
                 By.XPath("//*[@class='menu__nav menu--main__nav']//*[text()='COVID-19 Update']"),
                 new Dictionary<string,string>{
                     {WFMUtils.SelDescriptor.StdAttrNames.IsStatic, "y"},
-                    {"clickCausesPageLoad", "y"}
+                    {WFMUtils.SelDescriptor.StdAttrNames.ClickCausesPageLoad, "y"}
                 }
             );
         }

--- a/PageObjects/PrescriptiveMainPage.cs
+++ b/PageObjects/PrescriptiveMainPage.cs
@@ -27,42 +27,80 @@ namespace WFMPractice
                 "HomeLogoLink", 
                 By.CssSelector(".logo__link"),
                 new Dictionary<string,string>{
-                    {"isStatic", "y"}
+                    {"isStatic", "y"},
+                    {"clickCausesPageLoad", "y"}
                 }
             );
             this.AddSelDescriptor(
-                "WeeklySales", 
+                "Menu_WeeklySales", 
                 By.XPath("//*[@class='menu__nav menu--main__nav']//*[text()='Weekly Sales']"),
                 new Dictionary<string,string>{
-                    {"isStatic", "y"}
+                    {"isStatic", "y"},
+                    {"clickCausesPageLoad", "y"}
                 }
             );
             this.AddSelDescriptor(
-                "Tips&Ideas", 
+                "Button_SeeWeeklySales", 
+                By.XPath("//a[text()='See weekly sales']"),
+                new Dictionary<string,string>{
+                    {"isStatic", "y"},
+                    {"clickCausesPageLoad", "y"}
+                }
+            );
+            this.AddSelDescriptor(
+                "Menu_Tips&Ideas", 
                 By.XPath("//*[@class='menu__nav menu--main__nav']//*[text()='Tips & Ideas']"),
                 new Dictionary<string,string>{
-                    {"isStatic", "y"}
+                    {"isStatic", "y"},
+                    {"clickCausesPageLoad", "y"}
                 }
             );
             this.AddSelDescriptor(
-                "StoreLocator", 
+                "Menu_StoreLocator", 
                 By.XPath("//*[@class='menu__nav menu--main__nav']//*[text()='Store Locator']"),
                 new Dictionary<string,string>{
-                    {"isStatic", "y"}
+                    {"isStatic", "y"},
+                    {"clickCausesPageLoad", "y"}
                 }
             );
             this.AddSelDescriptor(
-                "BrowseProducts", 
+                "Button_FindAStore", 
+                By.XPath("//a[text()='Find a store']"),
+                new Dictionary<string,string>{
+                    {"isStatic", "y"},
+                    {"clickCausesPageLoad", "y"}
+                }
+            );
+            this.AddSelDescriptor(
+                "Menu_BrowseProducts", 
                 By.XPath("//*[@class='menu__nav menu--main__nav']//*[text()='Browse Products']"),
                 new Dictionary<string,string>{
-                    {"isStatic", "y"}
+                    {"isStatic", "y"},
+                    {"clickCausesPageLoad", "y"}
                 }
             );
             this.AddSelDescriptor(
-                "Covid19Update", 
+                "Button_BrowseProducts", 
+                By.XPath("//a[text()='Browse products']"),
+                new Dictionary<string,string>{
+                    {"isStatic", "y"},
+                    {"clickCausesPageLoad", "y"}
+                }
+            );
+            this.AddSelDescriptor(
+                "Button_GetDelivery&Pickup", 
+                By.XPath("//a[text()='Get delivery & pickup']"),
+                new Dictionary<string,string>{
+                    {"isStatic", "y"},
+                    {"clickCausesPageLoad", "y"}
+                }
+            );
+            this.AddSelDescriptor(
+                "Menu_Covid19Update", 
                 By.XPath("//*[@class='menu__nav menu--main__nav']//*[text()='COVID-19 Update']"),
                 new Dictionary<string,string>{
-                    {"isStatic", "y"}
+                    {"isStatic", "y"},
+                    {"clickCausesPageLoad", "y"}
                 }
             );
         }
@@ -70,43 +108,57 @@ namespace WFMPractice
         public void ClickToHomePage(int MaxWaitTimeInSecs=10)
         {
             ClickEltByName("HomeLogoLink");
-            WFMUtils.WaitForCurrPageToFinishLoading(driver, MaxWaitTimeInSecs);
+            // WFMUtils.WaitForCurrPageToFinishLoading(driver, MaxWaitTimeInSecs);
             Assert.That(driver.Url, Does.StartWith("https://www.wholefoodsmarket.com/"));
         }
 
 
-        public void ClickToWeeklySalesPage(int MaxWaitTimeInSecs=10)
+        public void ClickMenu_ToWeeklySalesPage(int MaxWaitTimeInSecs=10)
         {
-            ClickEltByName("WeeklySales");
-            WFMUtils.WaitForCurrPageToFinishLoading(driver, MaxWaitTimeInSecs);
+            ClickEltByName("Menu_WeeklySales");
+            // WFMUtils.WaitForCurrPageToFinishLoading(driver, MaxWaitTimeInSecs);
             Assert.That(driver.Url, Does.StartWith("https://www.wholefoodsmarket.com/sales-flyer"));
         }
 
-        public void ClickToTipsAndIdeasPage(int MaxWaitTimeInSecs=10)
+        public void ClickButton_SeeWeeklySalesPage(int MaxWaitTimeInSecs=10)
         {
-            ClickEltByName("Tips&Ideas");
-            WFMUtils.WaitForCurrPageToFinishLoading(driver, MaxWaitTimeInSecs);
+            ClickEltByName("Button_SeeWeeklySales");
+            // WFMUtils.WaitForCurrPageToFinishLoading(driver, MaxWaitTimeInSecs);
+            Assert.That(driver.Url, Does.StartWith("https://www.wholefoodsmarket.com/sales-flyer"));
+        }
+
+        public void ClickMenu_ToTipsAndIdeasPage(int MaxWaitTimeInSecs=10)
+        {
+            ClickEltByName("Menu_Tips&Ideas");
+            // WFMUtils.WaitForCurrPageToFinishLoading(driver, MaxWaitTimeInSecs);
             Assert.That(driver.Url, Does.StartWith("https://inspiration.wholefoodsmarket.com/"));
         }
 
-        public void ClickToStoreLocatorPage(int MaxWaitTimeInSecs=10)
+        public void ClickMenu_ToStoreLocatorPage(int MaxWaitTimeInSecs=10)
         {
-            ClickEltByName("StoreLocator");
-            WFMUtils.WaitForCurrPageToFinishLoading(driver, MaxWaitTimeInSecs);
+            ClickEltByName("Menu_StoreLocator");
+            // WFMUtils.WaitForCurrPageToFinishLoading(driver, MaxWaitTimeInSecs);
             Assert.That(driver.Url, Does.StartWith("https://www.wholefoodsmarket.com/stores"));
         }
 
-        public void ClickToBrowseProductsPage(int MaxWaitTimeInSecs=10)
+        public void ClickButton_FindAStore(int MaxWaitTimeInSecs=10)
         {
-            ClickEltByName("BrowseProducts");
-            WFMUtils.WaitForCurrPageToFinishLoading(driver, MaxWaitTimeInSecs);
+            ClickEltByName("Button_FindAStore");
+            // WFMUtils.WaitForCurrPageToFinishLoading(driver, MaxWaitTimeInSecs);
+            Assert.That(driver.Url, Does.StartWith("https://www.wholefoodsmarket.com/stores"));
+        }
+
+        public void ClickMenu_ToBrowseProductsPage(int MaxWaitTimeInSecs=10)
+        {
+            ClickEltByName("Menu_BrowseProducts");
+            // WFMUtils.WaitForCurrPageToFinishLoading(driver, MaxWaitTimeInSecs);
             Assert.That(driver.Url, Does.StartWith("https://products.wholefoodsmarket.com/"));
         }
 
-        public void ClickToCovid19UpdatePage(int MaxWaitTimeInSecs=10)
+        public void ClickMenu_ToCovid19UpdatePage(int MaxWaitTimeInSecs=10)
         {
-            ClickEltByName("Covid19Update");
-            WFMUtils.WaitForCurrPageToFinishLoading(driver, MaxWaitTimeInSecs);
+            ClickEltByName("Menu_Covid19Update");
+            // WFMUtils.WaitForCurrPageToFinishLoading(driver, MaxWaitTimeInSecs);
             Assert.That(driver.Url, Does.StartWith("https://www.wholefoodsmarket.com/company-info/covid-19-response"));
         }
     }

--- a/PageObjects/PrescriptiveMainPage.cs
+++ b/PageObjects/PrescriptiveMainPage.cs
@@ -60,11 +60,39 @@ namespace WFMPractice
             );
         }
 
+        public void ClickToWeeklySalesMenu(int MaxWaitTimeInSecs=10)
+        {
+            ClickEltByName("WeeklySales");
+            WFMUtils.WaitForCurrPageToFinishLoading(driver, MaxWaitTimeInSecs);
+            Assert.That(driver.Url, Does.StartWith("https://www.wholefoodsmarket.com/sales-flyer"));
+        }
+
+        public void ClickToTipsAndIdeasMenu(int MaxWaitTimeInSecs=10)
+        {
+            ClickEltByName("Tips&Ideas");
+            WFMUtils.WaitForCurrPageToFinishLoading(driver, MaxWaitTimeInSecs);
+            Assert.That(driver.Url, Does.StartWith("https://inspiration.wholefoodsmarket.com/"));
+        }
+
+        public void ClickToStoreLocatorMenu(int MaxWaitTimeInSecs=10)
+        {
+            ClickEltByName("StoreLocator");
+            WFMUtils.WaitForCurrPageToFinishLoading(driver, MaxWaitTimeInSecs);
+            Assert.That(driver.Url, Does.StartWith("https://www.wholefoodsmarket.com/stores"));
+        }
+
         public void ClickToBrowseProductsMenu(int MaxWaitTimeInSecs=10)
         {
-            driver.FindElement(this.GetBySelector("BrowseProducts")).Click();
+            ClickEltByName("BrowseProducts");
             WFMUtils.WaitForCurrPageToFinishLoading(driver, MaxWaitTimeInSecs);
             Assert.That(driver.Url, Does.StartWith("https://products.wholefoodsmarket.com/"));
+        }
+
+        public void ClickToCovid19UpdateMenu(int MaxWaitTimeInSecs=10)
+        {
+            ClickEltByName("Covid19Update");
+            WFMUtils.WaitForCurrPageToFinishLoading(driver, MaxWaitTimeInSecs);
+            Assert.That(driver.Url, Does.StartWith("https://www.wholefoodsmarket.com/company-info/covid-19-response"));
         }
     }
 }

--- a/PageObjects/WFMMainPage.cs
+++ b/PageObjects/WFMMainPage.cs
@@ -1,3 +1,5 @@
+using NUnit.Framework;
+
 using OpenQA.Selenium;
 using OpenQA.Selenium.Interactions;
 using OpenQA.Selenium.Support.UI;
@@ -29,7 +31,7 @@ namespace WFMPractice
             this.NavMenuSelectors.Add("BrowseProducts", By.XPath("//*[@class='menu__nav menu--main__nav']//*[text()='Browse Products']"));
             this.NavMenuSelectors.Add("Covid19Update", By.XPath("//*[@class='menu__nav menu--main__nav']//*[text()='COVID-19 Update']"));
         }
-                public void DoMenuHover(By MenuSelector, int HoverSleepTimeInMilliSecs=4000)
+        public void DoMenuHover(By MenuSelector, int HoverSleepTimeInMilliSecs=4000)
         {
             IWait<IWebDriver> wait = new WebDriverWait(driver, TimeSpan.FromSeconds(5));
             IWebElement element = wait.Until(ExpectedConditions.ElementIsVisible(MenuSelector));
@@ -56,6 +58,41 @@ namespace WFMPractice
             IWebElement subelement = wait2.Until(ExpectedConditions.ElementIsVisible(By.LinkText(LinkText)));
             action.MoveToElement(subelement);
             action.Click().Build().Perform();
+        }
+
+        public void ClickToWeeklySalesMenu(int MaxWaitTimeInSecs=10)
+        {
+            driver.FindElement(NavMenuSelectors["WeeklySales"]).Click();
+            WFMUtils.WaitForCurrPageToFinishLoading(driver, MaxWaitTimeInSecs);
+            Assert.That(driver.Url, Does.StartWith("https://www.wholefoodsmarket.com/sales-flyer"));
+        }
+
+        public void ClickToTipsAndIdeasMenu(int MaxWaitTimeInSecs=10)
+        {
+            driver.FindElement(NavMenuSelectors["Tips&Ideas"]).Click();
+            WFMUtils.WaitForCurrPageToFinishLoading(driver, MaxWaitTimeInSecs);
+            Assert.That(driver.Url, Does.StartWith("https://inspiration.wholefoodsmarket.com/"));
+        }
+
+        public void ClickToStoreLocatorMenu(int MaxWaitTimeInSecs=10)
+        {
+            driver.FindElement(NavMenuSelectors["StoreLocator"]).Click();
+            WFMUtils.WaitForCurrPageToFinishLoading(driver, MaxWaitTimeInSecs);
+            Assert.That(driver.Url, Does.StartWith("https://www.wholefoodsmarket.com/stores"));
+        }
+
+        public void ClickToBrowseProductsMenu(int MaxWaitTimeInSecs=10)
+        {
+            driver.FindElement(NavMenuSelectors["BrowseProducts"]).Click();
+            WFMUtils.WaitForCurrPageToFinishLoading(driver, MaxWaitTimeInSecs);
+            Assert.That(driver.Url, Does.StartWith("https://products.wholefoodsmarket.com/"));
+        }
+
+        public void ClickToCovid19UpdateMenu(int MaxWaitTimeInSecs=10)
+        {
+            driver.FindElement(NavMenuSelectors["Covid19Update"]).Click();
+            WFMUtils.WaitForCurrPageToFinishLoading(driver, MaxWaitTimeInSecs);
+            Assert.That(driver.Url, Does.StartWith("https://www.wholefoodsmarket.com/company-info/covid-19-response"));
         }
     }
 }

--- a/UnitTest1.cs
+++ b/UnitTest1.cs
@@ -19,7 +19,7 @@ namespace WFMPractice
         [SetUp]
         public void Setup()
         {
-            this.driver = WFMUtils.InitDriver("Chrome", "C:\\Users\\jefisher\\Documents\\WebDriver"); //"C:\\Users\\bshort\\WebDriver");
+            this.driver = WFMUtils.InitDriver("Chrome", "C:\\Users\\bshort\\WebDriver");
         }
 
         [Test]

--- a/UnitTest1.cs
+++ b/UnitTest1.cs
@@ -38,17 +38,17 @@ namespace WFMPractice
             Assert.That(driver.Url, Is.EqualTo(WFMMainPageURL));
 
             PrescriptiveMainPage PrescriptiveMainPageObj = new PrescriptiveMainPage(driver);
-            // PrescriptiveMainPageObj.ClickToWeeklySalesPage();
+            // PrescriptiveMainPageObj.ClickMenu_ToWeeklySalesPage();
             // PrescriptiveMainPageObj.ClickToHomePage();
-            // PrescriptiveMainPageObj.ClickToTipsAndIdeasPage();
+            // PrescriptiveMainPageObj.ClickMenu_ToTipsAndIdeasPage();
             // PrescriptiveMainPageObj.ClickToHomePage();
-            // PrescriptiveMainPageObj.ClickToStoreLocatorPage();
+            // PrescriptiveMainPageObj.ClickMenu_ToStoreLocatorPage();
             // PrescriptiveMainPageObj.ClickToHomePage();
-            PrescriptiveMainPageObj.ClickToBrowseProductsPage();
+            PrescriptiveMainPageObj.ClickMenu_ToBrowseProductsPage();
 
             PrescriptiveBrowseProductsPage PrescriptiveBrowseProductsPageObj = new PrescriptiveBrowseProductsPage(driver);
             PrescriptiveBrowseProductsPageObj.ClickToHomePage();
-            // PrescriptiveMainPageObj.ClickToCovid19UpdatePage();
+            // PrescriptiveMainPageObj.ClickMenu_ToCovid19UpdatePage();
             // PrescriptiveMainPageObj.ClickToHomePage();
             Thread.Sleep(2000); 
         }

--- a/UnitTest1.cs
+++ b/UnitTest1.cs
@@ -19,7 +19,7 @@ namespace WFMPractice
         [SetUp]
         public void Setup()
         {
-            this.driver = WFMUtils.InitDriver("Chrome", "C:\\Users\\bshort\\WebDriver");
+            this.driver = WFMUtils.InitDriver("Chrome", "C:\\Users\\jefisher\\Documents\\WebDriver"); //"C:\\Users\\bshort\\WebDriver");
         }
 
         [Test]

--- a/UnitTest1.cs
+++ b/UnitTest1.cs
@@ -13,12 +13,58 @@ namespace WFMPractice
     [TestFixture]
     public class Tests
     {
+        string WFMMainPageURL = "https://www.wholefoodsmarket.com/";
         IWebDriver driver;
 
-        [OneTimeSetUp]
+        [SetUp]
         public void Setup()
         {
             this.driver = WFMUtils.InitDriver("Chrome", "C:\\Users\\bshort\\WebDriver");
+        }
+
+        [Test]
+        public void TestWFMMainPageBringup2()
+        {
+            WFMUtils.LoadWebPage(driver, WFMMainPageURL);
+            Assert.That(driver.Url, Is.EqualTo(WFMMainPageURL));
+
+            Thread.Sleep(2000); 
+        }
+
+        [TestCase("WeeklySales", "https://www.wholefoodsmarket.com/sales-flyer")]
+        [TestCase("Tips&Ideas", "https://inspiration.wholefoodsmarket.com/")]
+        [TestCase("StoreLocator", "https://www.wholefoodsmarket.com/stores")]
+        [TestCase("BrowseProducts", "https://products.wholefoodsmarket.com/")]
+        [TestCase("Covid19Update", "https://www.wholefoodsmarket.com/company-info/covid-19-response")]
+        public void TestWFMMainPageMenuLinks2(string MenuCode, string DestUrl)
+        {
+            WFMUtils.LoadWebPage(driver, WFMMainPageURL);
+            Assert.That(driver.Url, Is.EqualTo(WFMMainPageURL));
+
+            WFMMainPage WFMMainPageObj = new WFMMainPage(driver);
+
+            driver.FindElement(WFMMainPageObj.NavMenuSelectors[MenuCode]).Click();
+            WFMUtils.WaitForCurrPageToFinishLoading(driver);
+            Assert.That(driver.Url, Does.StartWith(DestUrl));
+
+            Thread.Sleep(2000); 
+        }
+
+        [Test]
+        public void TestBrowseProducts_FindStore2()
+        {
+            WFMUtils.LoadWebPage(driver, WFMMainPageURL);
+            Assert.That(driver.Url, Is.EqualTo(WFMMainPageURL));
+
+            WFMMainPage WFMMainPageObj = new WFMMainPage(driver);
+            WFMMainPageObj.ClickToBrowseProductsMenu();
+
+            BrowseProductsPage BrowseProductsPageObj = new BrowseProductsPage(driver);
+            BrowseProductsPageObj.SetFindStoreSearchBoxText("FindStore", "78758");
+            BrowseProductsPageObj.ClickStoreFromSearch("FindStoreSearchResult", "Domain — 11920 Domain Dr, Austin, TX 78758");
+            Assert.That(driver.FindElement(BrowseProductsPageObj.PageElements["SavedStoreLocation"]).GetAttribute("innerText"), Is.EqualTo("Domain"));
+
+            Thread.Sleep(2000); 
         }
 
         [TestCase("WeeklySales")]
@@ -106,9 +152,9 @@ namespace WFMPractice
             Assert.AreEqual (BrowseProductsPageObj.PageElements["SavedStoreLocation"], "Domain");
             // BrowseProductsPageObj.SetProductSearchBoxText("ProductSearchBox", "Apple");
             Thread.Sleep(2000); 
-        }
+        }        
 
-        [OneTimeTearDown]
+        [TearDown]
         public void Close()
         {
             driver.Close();

--- a/UnitTest1.cs
+++ b/UnitTest1.cs
@@ -31,6 +31,28 @@ namespace WFMPractice
             Thread.Sleep(2000); 
         }
 
+        [Test]
+        public void TestPrescriptiveMainPage_ClickToOtherPages()
+        {
+            WFMUtils.LoadWebPage(driver, WFMMainPageURL);
+            Assert.That(driver.Url, Is.EqualTo(WFMMainPageURL));
+
+            PrescriptiveMainPage PrescriptiveMainPageObj = new PrescriptiveMainPage(driver);
+            // PrescriptiveMainPageObj.ClickToWeeklySalesPage();
+            // PrescriptiveMainPageObj.ClickToHomePage();
+            // PrescriptiveMainPageObj.ClickToTipsAndIdeasPage();
+            // PrescriptiveMainPageObj.ClickToHomePage();
+            // PrescriptiveMainPageObj.ClickToStoreLocatorPage();
+            // PrescriptiveMainPageObj.ClickToHomePage();
+            PrescriptiveMainPageObj.ClickToBrowseProductsPage();
+
+            PrescriptiveBrowseProductsPage PrescriptiveBrowseProductsPageObj = new PrescriptiveBrowseProductsPage(driver);
+            PrescriptiveBrowseProductsPageObj.ClickToHomePage();
+            // PrescriptiveMainPageObj.ClickToCovid19UpdatePage();
+            // PrescriptiveMainPageObj.ClickToHomePage();
+            Thread.Sleep(2000); 
+        }
+
         [TestCase("WeeklySales", "https://www.wholefoodsmarket.com/sales-flyer")]
         [TestCase("Tips&Ideas", "https://inspiration.wholefoodsmarket.com/")]
         [TestCase("StoreLocator", "https://www.wholefoodsmarket.com/stores")]

--- a/UnitTest1.cs
+++ b/UnitTest1.cs
@@ -63,7 +63,7 @@ namespace WFMPractice
             BrowseProductsPageObj.SetFindStoreSearchBoxText("FindStore", "78758");
             BrowseProductsPageObj.ClickStoreFromSearch("FindStoreSearchResult", "Domain — 11920 Domain Dr, Austin, TX 78758");
             Assert.That(driver.FindElement(BrowseProductsPageObj.PageElements["SavedStoreLocation"]).GetAttribute("innerText"), Is.EqualTo("Domain"));
-
+            WFMUtils.ScreenshotToFilepath(driver, "jeffshot.png");
             Thread.Sleep(2000); 
         }
 

--- a/Utils/WFMUtils.cs
+++ b/Utils/WFMUtils.cs
@@ -21,6 +21,12 @@ namespace WFMPractice
             public By BySelector;
             public Dictionary<string, string> AttrsDict;
             public string Name;
+            public class StdAttrNames 
+            { 
+                public static string IsStatic            = "isStatic";
+                public static string ClickCausesPageLoad = "clickCausesPageLoad";
+            }
+
             public SelDescriptor(string aName, By aBySelector, Dictionary<string,string> aAttrsDict)
             {
                 Name = aName;
@@ -123,7 +129,7 @@ namespace WFMPractice
 
             public void WaitForAllStaticEltsToBeVisible(int aTimeoutInSecs=10)
             {
-                List<By> StaticEltsBySelectorsList = SelsMgr.GetBySelectorsList_EltsHavingAttrName("isStatic");
+                List<By> StaticEltsBySelectorsList = SelsMgr.GetBySelectorsList_EltsHavingAttrName(SelDescriptor.StdAttrNames.IsStatic);
                 WaitForAllEltsToBeVisible(driver, StaticEltsBySelectorsList, aTimeoutInSecs);
             }            
 
@@ -144,7 +150,7 @@ namespace WFMPractice
                 SelDescriptor CurrSelDescriptor = SelsMgr.GetSelDescriptor(aEltName);
                 IWebElement elt = driver.FindElement(CurrSelDescriptor.BySelector);
                 elt.Click();
-                if (CurrSelDescriptor.HasAttr("ClickCausesPageLoad"))
+                if (CurrSelDescriptor.HasAttr(SelDescriptor.StdAttrNames.ClickCausesPageLoad))
                 {
                     WaitForCurrPageToFinishLoading(driver, MaxWaitTimeInSecs);
                     return null;

--- a/Utils/WFMUtils.cs
+++ b/Utils/WFMUtils.cs
@@ -1,10 +1,15 @@
+using NUnit.Framework;
+
 using OpenQA.Selenium;
 using OpenQA.Selenium.Interactions;
 using OpenQA.Selenium.Support.UI;
 using OpenQA.Selenium.Firefox;
 using OpenQA.Selenium.Chrome;
+
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Drawing.Imaging;
 
 
 namespace WFMPractice
@@ -108,6 +113,20 @@ namespace WFMPractice
            ).Until(
                ExpectedConditions.ElementIsVisible(BySelector)
            );
+        }
+
+        public static void ScreenshotToFilepath(IWebDriver driver, string Filepath)
+        {
+            try
+            {
+                Screenshot image = ((ITakesScreenshot) driver).GetScreenshot();
+                image.SaveAsFile(Filepath, ScreenshotImageFormat.Png);
+            }
+            catch (Exception e)
+            {
+               Debug.WriteLine(e);
+               Assert.Fail("Exception creating screenshot!\n" + e);
+            }
         }         
     }
 }

--- a/Utils/WFMUtils.cs
+++ b/Utils/WFMUtils.cs
@@ -36,6 +36,11 @@ namespace WFMPractice
                 }
                 return false;
             }
+
+            public string GetAttrVal(string aAttrName)
+            {
+                return AttrsDict[aAttrName];
+            }
         } 
 
         public class SelsMgr
@@ -56,18 +61,32 @@ namespace WFMPractice
                 return SelsDict[aName].BySelector;
             }
 
-            public List<By> GetEltsHavingAttrBySelectorsList(string aAttrName)
+            public List<By> GetBySelectorsList_EltsHavingAttrName(string aAttrName)
             {
-                List<By> StaticBySelectorsList = new List<By>();
+                List<By> BySelectorsList = new List<By>();
 
-                foreach(KeyValuePair<string, SelDescriptor> CurrSelDictEntry in SelsDict)
+                foreach(KeyValuePair<string, SelDescriptor> CurrSelKV in SelsDict)
                 {
-                    if (CurrSelDictEntry.Value.HasAttr(aAttrName))
+                    if (CurrSelKV.Value.HasAttr(aAttrName))
                     {
-                        StaticBySelectorsList.Add(CurrSelDictEntry.Value.BySelector);
+                        BySelectorsList.Add(CurrSelKV.Value.BySelector);
                     }
                 }
-                return StaticBySelectorsList;
+                return BySelectorsList;
+            }
+
+            public List<By> GetBySelectorsList_EltsHavingAttrNameVal(string aAttrName, string aAttrVal)
+            {
+                List<By> BySelectorsList = new List<By>();
+
+                foreach(KeyValuePair<string, SelDescriptor> CurrSelKV in SelsDict)
+                {
+                    if (CurrSelKV.Value.HasAttr(aAttrName) && CurrSelKV.Value.GetAttrVal(aAttrVal) == aAttrVal)
+                    {
+                        BySelectorsList.Add(CurrSelKV.Value.BySelector);
+                    }
+                }
+                return BySelectorsList;
             }
         } 
 
@@ -98,7 +117,7 @@ namespace WFMPractice
 
             public void WaitForAllStaticEltsToBeVisible(int aTimeoutInSecs=10)
             {
-                List<By> StaticEltsBySelectorsList = SelsMgr.GetEltsHavingAttrBySelectorsList("isStatic");
+                List<By> StaticEltsBySelectorsList = SelsMgr.GetBySelectorsList_EltsHavingAttrName("isStatic");
                 WaitForAllEltsToBeVisible(driver, StaticEltsBySelectorsList, aTimeoutInSecs);
             }            
 
@@ -112,6 +131,13 @@ namespace WFMPractice
                 );
 
                 WaitForAllStaticEltsToBeVisible(aTimeoutInSecs);
+            }
+
+            public IWebElement ClickEltByName(string aEltName)
+            {
+                IWebElement elt = driver.FindElement(SelsMgr.GetBySelector(aEltName));
+                elt.Click();
+                return elt;
             }
         }
 
@@ -191,6 +217,35 @@ namespace WFMPractice
                Debug.WriteLine(e);
                Assert.Fail("Exception creating screenshot!\n" + e);
             }
-        }         
+        } 
+
+        public void HoverOverElt(IWebDriver driver, By EltSelector, int HoverTimeInSecs=3, int TimeoutInSecs=10)
+        {
+            IWait<IWebDriver> wait = new WebDriverWait(driver, TimeSpan.FromSeconds(5));
+            IWebElement element = wait.Until(ExpectedConditions.ElementIsVisible(EltSelector));
+            Actions action = new Actions(driver);
+            action.MoveToElement(element).Build().Perform();
+
+            if (HoverTimeInSecs > 0) { 
+                System.Threading.Thread.Sleep(TimeSpan.FromSeconds(HoverTimeInSecs));
+            }
+        }
+
+        public void HoverOverEltThenClickLinkText(IWebDriver driver, By EltSelector, string LinkText, int HoverTimeInSecs=3, int TimeoutInSecs=10)
+        {
+            IWait<IWebDriver> wait = new WebDriverWait(driver, TimeSpan.FromSeconds(10));
+            IWebElement element = wait.Until(ExpectedConditions.ElementIsVisible(EltSelector));
+            Actions action = new Actions(driver);
+            action.MoveToElement(element).Build().Perform();
+
+            if (HoverTimeInSecs > 0) {
+                System.Threading.Thread.Sleep(TimeSpan.FromSeconds(HoverTimeInSecs));
+            }
+
+            IWait<IWebDriver> wait2 = new WebDriverWait(driver, TimeSpan.FromSeconds(TimeoutInSecs));
+            IWebElement subelement = wait2.Until(ExpectedConditions.ElementIsVisible(By.LinkText(LinkText)));
+            action.MoveToElement(subelement);
+            action.Click().Build().Perform();
+        }                        
     }
 }

--- a/Utils/WFMUtils.cs
+++ b/Utils/WFMUtils.cs
@@ -99,11 +99,11 @@ namespace WFMPractice
         
             public POM(string aPath, IWebDriver aDriver)
             {
-                POMRegistry.Add(Path, this); // Add this POM to the registry
-
                 Path = aPath;
                 driver = aDriver;
                 SelsMgr = new SelsMgr();
+
+                POMRegistry.Add(Path, this); // Add this POM to the registry
             }
 
             public void AddSelDescriptor(string aName, By aBySelector, Dictionary<string,string> aAttrsDict)

--- a/Utils/WFMUtils.cs
+++ b/Utils/WFMUtils.cs
@@ -21,7 +21,7 @@ namespace WFMPractice
             public By BySelector;
             public Dictionary<string, string> AttrsDict;
             public string Name;
-            public SelDescriptor(string aName, By aBySelector, Dictionary<string, string> aAttrsDict)
+            public SelDescriptor(string aName, By aBySelector, Dictionary<string,string> aAttrsDict)
             {
                 Name = aName;
                 BySelector = aBySelector;
@@ -31,29 +31,46 @@ namespace WFMPractice
 
         public class SelsMgr
         {
-            Dictionary<string, SelDescriptor> SelsDict;
+            public Dictionary<string, SelDescriptor> SelsDict;
 
             public SelsMgr()
             {
                 SelsDict = new Dictionary<string, SelDescriptor>();
             }
-            public void AddSelDescriptor(SelDescriptor aSelDesc)
+            public void AddSelDescriptor(string aName, By aBySelector, Dictionary<string,string> aAttrsDict)
             {
-                SelsDict.Add(aSelDesc.Name, aSelDesc);
+                SelsDict.Add(aName, new SelDescriptor(aName, aBySelector, aAttrsDict));
+            }
+
+            public By GetBySelector(string aName)
+            {
+                return SelsDict[aName].BySelector;
             }
         } 
 
         public class POM
         {
-            public Dictionary<string, POM> POMTracker = new Dictionary<string, POM>();
+            public static Dictionary<string, POM> POMRegistry = new Dictionary<string, POM>();
+            public IWebDriver driver;
             public string Path;
-            public SelsMgr SelMgr;
+            public SelsMgr SelsMgr;
         
-            public POM(string aPath, SelsMgr aSelectorsMgr)
+            public POM(string aPath, IWebDriver aDriver)
             {
+                POMRegistry.Add(Path, this); // Add this POM to the registry
+
                 Path = aPath;
-                SelMgr = aSelectorsMgr;
-                POMTracker.Add(Path, this);
+                driver = aDriver;
+                SelsMgr = new SelsMgr();
+            }
+
+            public void AddSelDescriptor(string aName, By aBySelector, Dictionary<string,string> aAttrsDict)
+            {
+                this.SelsMgr.AddSelDescriptor(aName, aBySelector, aAttrsDict);
+            }
+            public By GetBySelector(string aName)
+            {
+                return SelsMgr.GetBySelector(aName);
             }
         }
 

--- a/Utils/WFMUtils.cs
+++ b/Utils/WFMUtils.cs
@@ -55,6 +55,17 @@ namespace WFMPractice
         public static void LoadWebPage(IWebDriver driver, string Url, int TimeoutInSecs=10) 
         {
             driver.Url = Url;
+            WaitForCurrPageToFinishLoading(driver, TimeoutInSecs);
+            // new WebDriverWait(
+            //     driver, 
+            //     TimeSpan.FromSeconds(TimeoutInSecs)
+            // ).Until(
+            //     d => ((IJavaScriptExecutor) d).ExecuteScript("return document.readyState").Equals("complete")
+            // );
+        }
+
+        public static void WaitForCurrPageToFinishLoading(IWebDriver driver, int TimeoutInSecs=10) 
+        {
             new WebDriverWait(
                 driver, 
                 TimeSpan.FromSeconds(TimeoutInSecs)

--- a/Utils/WFMUtils.cs
+++ b/Utils/WFMUtils.cs
@@ -61,6 +61,12 @@ namespace WFMPractice
                 return SelsDict[aName].BySelector;
             }
 
+            public SelDescriptor GetSelDescriptor(string aName)
+            {
+                return SelsDict[aName];
+            }
+
+
             public List<By> GetBySelectorsList_EltsHavingAttrName(string aAttrName)
             {
                 List<By> BySelectorsList = new List<By>();
@@ -133,11 +139,19 @@ namespace WFMPractice
                 WaitForAllStaticEltsToBeVisible(aTimeoutInSecs);
             }
 
-            public IWebElement ClickEltByName(string aEltName)
+            public IWebElement ClickEltByName(string aEltName, int MaxWaitTimeInSecs=10)
             {
-                IWebElement elt = driver.FindElement(SelsMgr.GetBySelector(aEltName));
+                SelDescriptor CurrSelDescriptor = SelsMgr.GetSelDescriptor(aEltName);
+                IWebElement elt = driver.FindElement(CurrSelDescriptor.BySelector);
                 elt.Click();
-                return elt;
+                if (CurrSelDescriptor.HasAttr("ClickCausesPageLoad"))
+                {
+                    WaitForCurrPageToFinishLoading(driver, MaxWaitTimeInSecs);
+                    return null;
+                } else
+                {
+                    return elt;
+                }
             }
         }
 


### PR DESCRIPTION
Changed the "OneTimeSetup" and "OneTimeTearDown" strings in UnitTest1.cs to "Setup" and "TearDown" to avoid cross-test contamination.

TestWFMMainPageBringup2() is new, merely brings up the Main Page

TestWFMMainPageMenuLinks2() is new, replaces TestWFMMainPageMenu()
Validates each of the links take you to the intended destination.

It seems to obviate the following tests in their current form:
    TestWeeklySalesClick()
    TestTipsAndIdeasClick()
    TestStoreLocatorClick()
    TestBrowseProductsClick()
    TestCOVID19UpdateClick()

but those tests could be grown into something more
sophisticated.  I also don't understand what WFMMainPageObj.Equals() is for.

TestBrowseProducts_Search2() is new, replaces TestSearchProducts()
    This new test doesn't go directly to the URL, it navs to it via POM methods, like a customer would.
    Took out the extra Thread.Sleep().  Ideally, shouldn't have Thread.Sleep()'s--except
to slow down the automation so it can be viewed

I've also added some new functions/methods to support the above. More Asserting, using Assert.That() that is more in vogue.

Added these BrowseProductPages methods so tests can nav to the various menus:
ClickToWeeklySalesMenu()
ClickToTipsAndIdeasMenu
ClickToStoreLocatorMenu()
ClickToBrowseProductsMenu()
ClickToCovid19UpdateMenu()

